### PR TITLE
Fix comment view access

### DIFF
--- a/includes/forum_access.comment.inc
+++ b/includes/forum_access.comment.inc
@@ -64,7 +64,10 @@ function forum_access_comment_access(\Drupal\Core\Entity\EntityInterface $entity
     // Check if user is author of comment.
     $is_author = $account->id() == $comment_author->id();
 
-    if ($operation == 'update'
+    if ($operation == 'view' && forum_access_access('view', $tid)) {
+      return AccessResult::allowed();
+    }
+    elseif ($operation == 'update'
         && (forum_access_access('update', $tid) || $account->hasPermission('edit any forum content') || $is_author && $account->hasPermission('edit own forum content'))) {
       return AccessResult::allowed();
     }


### PR DESCRIPTION
After performing more tests, found one more problem:

- Forum users are getting **Access denied** when trying to access the link to approved comments.

I believe I found a solution.